### PR TITLE
Counters can use different update times now

### DIFF
--- a/LunarMooner/include/LMCounterDisplay.hpp
+++ b/LunarMooner/include/LMCounterDisplay.hpp
@@ -48,7 +48,7 @@ namespace lm
     class CounterDisplay final : public sf::Drawable, public sf::Transformable
     {
     public:
-        CounterDisplay(sf::Texture&, sf::Uint8);
+        CounterDisplay(sf::Texture&, sf::Uint8, sf::Time);
         ~CounterDisplay() = default;
         CounterDisplay(const CounterDisplay&) = delete;
         CounterDisplay& operator = (const CounterDisplay&) = delete;
@@ -69,6 +69,7 @@ namespace lm
             sf::Int8 factor = 0;
             sf::Vector2f size;
             sf::Time timeSinceValueChange = sf::seconds(0);
+            sf::Time updateTime;
             void update(float);
         };
         std::vector<SubRect> m_subRects;

--- a/LunarMooner/src/LMCounterDisplay.cpp
+++ b/LunarMooner/src/LMCounterDisplay.cpp
@@ -41,10 +41,9 @@ using namespace lm;
 namespace
 {
     const float textSpacing = 34.f;
-    const sf::Time	updateTime = sf::seconds(2);	//the time taken to update the value
 }
 
-CounterDisplay::CounterDisplay(sf::Texture& texture, sf::Uint8 digitCount)
+CounterDisplay::CounterDisplay(sf::Texture& texture, sf::Uint8 digitCount, sf::Time updateTime)
     : m_currentValue(0),
     m_subRects      (digitCount),
     m_texture       (texture),
@@ -75,7 +74,9 @@ CounterDisplay::CounterDisplay(sf::Texture& texture, sf::Uint8 digitCount)
         m_vertices[v++] = m_subRects[i].vertices[1];
         m_vertices[v++] = m_subRects[i].vertices[2];
         m_vertices[v++] = m_subRects[i].vertices[3];
-        
+
+        m_subRects[i].updateTime = updateTime;
+
         //tell it which factor this digit is displaying
         m_subRects[i].factor = digitCount - 1 - factor++; //abrakadabra
     }

--- a/LunarMooner/src/LMPlayerInfoDisplay.cpp
+++ b/LunarMooner/src/LMPlayerInfoDisplay.cpp
@@ -199,9 +199,9 @@ void ScoreDisplay::ScoreTag::update(float dt)
 //ui elements struct
 ScoreDisplay::UIElements::UIElements(ResourceCollection& rc, sf::Uint8 player)
     : clockDisplay  (rc.textureResource.get("assets/images/game/console/nixie_sheet.png")),
-    ammo            (rc.textureResource.get("assets/images/game/console/counter.png"), 2),
-    lives           (rc.textureResource.get("assets/images/game/console/counter.png"), 2),
-    score           (rc.textureResource.get("assets/images/game/console/counter.png"), 6),
+    ammo            (rc.textureResource.get("assets/images/game/console/counter.png"), 2, sf::seconds(0.5f)),
+    lives           (rc.textureResource.get("assets/images/game/console/counter.png"), 2, sf::seconds(0.5f)),
+    score           (rc.textureResource.get("assets/images/game/console/counter.png"), 6, sf::seconds(2.0f)),
     level           (rc.textureResource.get("assets/images/game/console/level_meter.png"))
 {
     //hackety blunge to layout elements


### PR DESCRIPTION
Made it a parameter of the constructor. Have used 0.5 seconds for the ammo and life counters, 2 seconds for the score counter. Tweak as you see fit!
